### PR TITLE
Floor slicing feature

### DIFF
--- a/qcli/bsp2svg/cli.py
+++ b/qcli/bsp2svg/cli.py
@@ -40,21 +40,18 @@ def main():
     )
 
     parser.add_argument(
-        '-a', '--axis',
-        dest='axis',
+        '-p', '--projection-axis',
+        dest='projection_axis',
         choices=['x', 'y', 'z'],
         default='z',
         help='projection axis. "z" (default) will create a top down view, "x" and "y" will create a frontal and lateral view'
     )
 
     parser.add_argument(
-        '-p', '--parameters',
-        dest='params',
-        metavar=(1, 0.5, 64),
-        nargs=3,
-        type=float,
-        default=[1, 0.5, 64],
-        help='automatic floor detection parameters. the detection works in 3 passes, each parameter is a number that affects each pass. the first is floor_threshold, defaults to 1, usable values are in (1, 32) range. affects the initial detection of floors, smaller values will detect more floors. the second is fake_floor_ratio, defaults to 0.5, usable values are in the (0.01, 0.9) range. it represents the ratio of floor/biggest_floor, any floor below this ratio will be ignored. the third is floor_merge_threshold, defaults to 64, usable values are in the (16, 96) range. this affects the last pass in the floor trimming procedure, any previously detected floors that are followed by a floor at less z-distance than this param will be ignored.'
+        '-l', '--slicing-axis',
+        dest='slicing_axis',
+        choices=['x', 'y', 'z'],
+        help='slicing axis. the slices will be aligned to this axis. if not specified, the projection axis will be used for slicing as well. a common use case is to use "z" for slicing and "x" or "y" for projection. only relevant when using the -f option, otherwise it\s ignored'
     )
 
     parser.add_argument(
@@ -67,12 +64,22 @@ def main():
     )
 
     parser.add_argument(
-        '-f', '--floors',
-        dest='floors',
-        metavar='floor',
+        '-s', '--slices',
+        dest='slices',
+        metavar='slice',
         nargs='*',
         type=float,
-        help='enables floor slicing functionality. without any parameters, it will also enable automatic floor detection. it can have additional number parameters representing floor heigts where slices are created.'
+        help='enables slicing functionality. without any parameters, it will also enable automatic floor / wall detection. it can have additional number parameters representing floor / wall distances where slices are created'
+    )
+
+    parser.add_argument(
+        '-t', '--detection-parameters',
+        dest='detection_params',
+        metavar=(1, 0.5, 64),
+        nargs=3,
+        type=float,
+        default=[1, 0.5, 64],
+        help='automatic slice detection parameters. the detection works in 3 passes, each parameter is a number that affects each pass. the first is slice_threshold, defaults to 1, usable values are in (1, 32) range. affects the initial detection of floors / walls, smaller values will detect more floors / walls. the second is fake_slice_ratio, defaults to 0.5, usable values are in the (0.01, 0.9) range. it represents the ratio of slice/biggest_slice, any slice below this ratio will be ignored. the third is slice_merge_threshold, defaults to 64, usable values are in the (16, 96) range. this affects the last pass in the slice trimming procedure, any previously detected slices that are followed by a slice at less distance than this param will be ignored.'
     )
 
     parser.add_argument(
@@ -98,7 +105,7 @@ def main():
     # Validate or create out file
     if args.dest == os.getcwd():
         svg_path = os.path.dirname(args.file)
-        svg_name = f'{os.path.basename(args.file).split(".")[0]}_{args.axis}.svg'
+        svg_name = f'{os.path.basename(args.file).split(".")[0]}_{args.projection_axis}_{args.slicing_axis or args.projection_axis}.svg'
         args.dest = os.path.join(svg_path, svg_name)
 
     dest_dir = os.path.dirname(args.dest) or '.'

--- a/qcli/bsp2svg/cli.py
+++ b/qcli/bsp2svg/cli.py
@@ -42,6 +42,14 @@ def main():
     )
 
     parser.add_argument(
+        '-a', '--axis',
+        choices=['x', 'y', 'z'],
+        dest='axis',
+        default='z',
+        help='projection axis'
+    )
+
+    parser.add_argument(
         '-i', '--ignore',
         dest='ignore',
         metavar='name',
@@ -53,10 +61,9 @@ def main():
     parser.add_argument(
         '-f', '--floors',
         dest='floors',
-        metavar='name',
         nargs='*',
         default=[],
-        help='floor heigts where slices are created'
+        help='floor heigts where slices are created. skip for automatic floor detection'
     )
 
     parser.add_argument(
@@ -82,7 +89,7 @@ def main():
     # Validate or create out file
     if args.dest == os.getcwd():
         svg_path = os.path.dirname(args.file)
-        svg_name = f'{os.path.basename(args.file).split(".")[0]}.svg'
+        svg_name = f'{os.path.basename(args.file).split(".")[0]}_{args.axis}.svg'
         args.dest = os.path.join(svg_path, svg_name)
 
     dest_dir = os.path.dirname(args.dest) or '.'

--- a/qcli/bsp2svg/cli.py
+++ b/qcli/bsp2svg/cli.py
@@ -1,4 +1,4 @@
-"""Command line utility for creating and creating WAD files from BSP files
+"""Command line utility for creating SVG files from BSP files
 
 Supported Games:
     - QUAKE
@@ -12,8 +12,6 @@ import sys
 
 from vgio.quake import bsp
 
-# sys.path.insert(0, '../../')
-sys.path.insert(0, 'C:/gitprojects/quake-cli-tools/')
 import qcli
 from qcli.bsp2svg import converter
 from qcli.common import Parser, ResolvePathAction

--- a/qcli/bsp2svg/cli.py
+++ b/qcli/bsp2svg/cli.py
@@ -56,7 +56,7 @@ def main():
         nargs=3,
         type=float,
         default=[1, 0.5, 64],
-        help='automatic floor detection parameters. the detection works in 3 passes, each parameter is a number that affects each pass. the first is floor_threshold, defaults to 1, usable values are in (1, 32) range. affects the initial detection of floors, smaller values will detect mor floors. the second is fake_floor_ratio, defaults to 0.5, usable values are in the (0.01, 0.9) range. it represents the ratio of floor/biggest_floor, any floor below this ratio will be ignored. the third is floor_merge_threshold, defaults to 64, usable values are in the (16, 96) range. this affects the last pass in the floor trimming procedure, any previously detected floors that are followed by a floor at less z-distance than this param will be ignored.'
+        help='automatic floor detection parameters. the detection works in 3 passes, each parameter is a number that affects each pass. the first is floor_threshold, defaults to 1, usable values are in (1, 32) range. affects the initial detection of floors, smaller values will detect more floors. the second is fake_floor_ratio, defaults to 0.5, usable values are in the (0.01, 0.9) range. it represents the ratio of floor/biggest_floor, any floor below this ratio will be ignored. the third is floor_merge_threshold, defaults to 64, usable values are in the (16, 96) range. this affects the last pass in the floor trimming procedure, any previously detected floors that are followed by a floor at less z-distance than this param will be ignored.'
     )
 
     parser.add_argument(
@@ -74,8 +74,7 @@ def main():
         metavar='floor',
         nargs='*',
         type=float,
-        default=[],
-        help='numbers representing floor heigts where slices are created. skip for automatic floor detection'
+        help='enables floor slicing functionality. without any parameters, it will also enable automatic floor detection. it can have additional number parameters representing floor heigts where slices are created.'
     )
 
     parser.add_argument(

--- a/qcli/bsp2svg/cli.py
+++ b/qcli/bsp2svg/cli.py
@@ -75,10 +75,10 @@ def main():
     parser.add_argument(
         '-t', '--detection-parameters',
         dest='detection_params',
-        metavar=(1, 0.5, 64),
+        metavar=(1, 0.3, 64),
         nargs=3,
         type=float,
-        default=[1, 0.5, 64],
+        default=[1, 0.3, 64],
         help='automatic slice detection parameters. the detection works in 3 passes, each parameter is a number that affects each pass. the first is slice_threshold, defaults to 1, usable values are in (1, 32) range. affects the initial detection of floors / walls, smaller values will detect more floors / walls. the second is fake_slice_ratio, defaults to 0.5, usable values are in the (0.01, 0.9) range. it represents the ratio of slice/biggest_slice, any slice below this ratio will be ignored. the third is slice_merge_threshold, defaults to 64, usable values are in the (16, 96) range. this affects the last pass in the slice trimming procedure, any previously detected slices that are followed by a slice at less distance than this param will be ignored.'
     )
 
@@ -105,7 +105,8 @@ def main():
     # Validate or create out file
     if args.dest == os.getcwd():
         svg_path = os.path.dirname(args.file)
-        svg_name = f'{os.path.basename(args.file).split(".")[0]}_{args.projection_axis}_{args.slicing_axis or args.projection_axis}.svg'
+        svg_suffix = f"_{args.projection_axis}_{args.slicing_axis or args.projection_axis}" if args.slices != None else ""
+        svg_name = f'{os.path.basename(args.file).split(".")[0]}{svg_suffix}.svg'
         args.dest = os.path.join(svg_path, svg_name)
 
     dest_dir = os.path.dirname(args.dest) or '.'

--- a/qcli/bsp2svg/cli.py
+++ b/qcli/bsp2svg/cli.py
@@ -43,10 +43,20 @@ def main():
 
     parser.add_argument(
         '-a', '--axis',
-        choices=['x', 'y', 'z'],
         dest='axis',
+        choices=['x', 'y', 'z'],
         default='z',
-        help='projection axis'
+        help='projection axis. "z" (default) will create a top down view, "x" and "y" will create a frontal and lateral view'
+    )
+
+    parser.add_argument(
+        '-p', '--parameters',
+        dest='params',
+        metavar=(1, 0.5, 64),
+        nargs=3,
+        type=float,
+        default=[1, 0.5, 64],
+        help='automatic floor detection parameters. the detection works in 3 passes, each parameter is a number that affects each pass. the first is floor_threshold, defaults to 1, usable values are in (1, 32) range. affects the initial detection of floors, smaller values will detect mor floors. the second is fake_floor_ratio, defaults to 0.5, usable values are in the (0.01, 0.9) range. it represents the ratio of floor/biggest_floor, any floor below this ratio will be ignored. the third is floor_merge_threshold, defaults to 64, usable values are in the (16, 96) range. this affects the last pass in the floor trimming procedure, any previously detected floors that are followed by a floor at less z-distance than this param will be ignored.'
     )
 
     parser.add_argument(
@@ -61,9 +71,11 @@ def main():
     parser.add_argument(
         '-f', '--floors',
         dest='floors',
+        metavar='floor',
         nargs='*',
+        type=float,
         default=[],
-        help='floor heigts where slices are created. skip for automatic floor detection'
+        help='numbers representing floor heigts where slices are created. skip for automatic floor detection'
     )
 
     parser.add_argument(

--- a/qcli/bsp2svg/cli.py
+++ b/qcli/bsp2svg/cli.py
@@ -12,6 +12,8 @@ import sys
 
 from vgio.quake import bsp
 
+# sys.path.insert(0, '../../')
+sys.path.insert(0, 'C:/gitprojects/quake-cli-tools/')
 import qcli
 from qcli.bsp2svg import converter
 from qcli.common import Parser, ResolvePathAction
@@ -46,6 +48,15 @@ def main():
         nargs='*',
         default=[],
         help='texture names to ignore'
+    )
+
+    parser.add_argument(
+        '-f', '--floors',
+        dest='floors',
+        metavar='name',
+        nargs='*',
+        default=[],
+        help='floor heigts where slices are created'
     )
 
     parser.add_argument(

--- a/qcli/bsp2svg/converter.py
+++ b/qcli/bsp2svg/converter.py
@@ -149,7 +149,7 @@ def convert(bsp_file, svg_file, args):
         if projection_axis == 'x':
             return vertexes[1:3]
         elif projection_axis == 'y':
-            return [vertexes[0], vertexes[2]]
+            return vertexes[0], vertexes[2]
         elif projection_axis == 'z':
             return vertexes[:2]
 

--- a/qcli/bsp2svg/converter.py
+++ b/qcli/bsp2svg/converter.py
@@ -55,11 +55,14 @@ def get_clustered_slices(values, args):
             slices_merged.append(slice_distance)
         crt_distance = slice_distance
 
-    top_height = values_sorted[len(values) - 1]
+    bottom_slice = values_sorted[0]
+    top_slice = values_sorted[len(values) - 1]
     if not args.quiet:
-        print(f'will also include bottom and ceiling: {values_sorted[0]}, {top_height}')
-    slices_merged.insert(0, values_sorted[0])
-    slices_merged.append(top_height)
+        print(f'will also include bottom and top: {bottom_slice}, {top_slice}')
+    if slices_merged[0] != bottom_slice:
+        slices_merged.insert(0, bottom_slice)
+    if slices_merged[len(slices_merged) - 1] != top_slice:
+        slices_merged.append(top_slice)
     if not args.quiet:
         print(f'slices after merging: {slices_merged}')
 

--- a/qcli/bsp2svg/converter.py
+++ b/qcli/bsp2svg/converter.py
@@ -18,13 +18,11 @@ def simplify_number(number):
     """
     return int(number) if int(number) == number else number
 
-def get_clustered_floor_heights(zvalues):
+def get_clustered_floor_heights(zvalues, parameters):
     clusters = []
-    # TODO Configurable parameters with default values
-    # TODO Description for each parameter
-    floor_threshold = 1
-    fake_floor_ratio = 0.25
-    floor_merge_threshold = 96
+    floor_threshold = parameters[0]
+    fake_floor_ratio = parameters[1]
+    floor_merge_threshold = parameters[2]
     zvalues_sorted = sorted(zvalues)
     crt_point = zvalues_sorted[0]
     crt_cluster = [crt_point]
@@ -93,7 +91,7 @@ def convert(bsp_file, svg_file, args):
     zfaces = list(filter(lambda f: f.plane.type == 2, faces))
     zheights = [int(face.plane.distance) for face in zfaces]
     # zheights = [vertex[:][2] for face in zfaces for vertex in face.vertexes]
-    floors = list(map(lambda s: float(s), args.floors)) if len(args.floors) > 0 else get_clustered_floor_heights(zheights)
+    floors = args.floors if len(args.floors) > 0 else get_clustered_floor_heights(zheights, args.params)
 
     drawing_xs = xs if projection_axis in ['y', 'z'] else ys
     drawing_ys = zs if projection_axis in ['x', 'y'] else ys
@@ -157,7 +155,8 @@ def convert(bsp_file, svg_file, args):
         points = [tuple(map(simplify_number, p)) for p in points]
 
         # Draw the complete polygon
-        complete_group.add(dwg.polygon(points))
+        # TODO Find a way to create the complete polygon and avoid doubling everything
+        # complete_group.add(dwg.polygon(points))
 
         was_added = False
         # Find the correct layer to draw on, based on height

--- a/qcli/bsp2svg/converter.py
+++ b/qcli/bsp2svg/converter.py
@@ -162,6 +162,7 @@ def convert(bsp_file, svg_file, args):
         was_added = False
         # Find the correct layer to draw on, based on distance
         for i in range(len(dwg_tuples) - 1):
+            crt_face_dist = 0
             if slicing_axis == 'x':
                 crt_face_dist = face.vertexes[0].x
             elif slicing_axis == 'y':


### PR DESCRIPTION
This PR adds the Floor slicing feature for the `bsp2svg` tool
  - disabled by default
  - it includes automatic floor detection, the detection parameters can be adjusted with arguments
  - before / after screenshot - the saint.bsp map from Honey, with the top floor hidden https://imgsli.com/MjIwNDIx
  - if there is more than one floor detected / configured, the export will also include a hidden layer that has all floors (identical to the old export)

# Examples
- `bsp2svg.exe e4m1.bsp -s` enables slicing with everything default
- `bsp2svg.exe e1m1.bsp -s -t 1 0.25 32` slices with different floor detection parameters, by the default axis (z)
- `bsp2svg.exe alk_tellus.bsp -s -t 1 0.2 96 -i flat01` as above, but different parameters and an extra ignored texture
- `bsp2svg.exe alk_tellus.bsp -s -p y -l z -t 1 0.2 96 -i flat01` as above, and additionally projected by the `y` axis, sliced by `z`
- `bsp2svg.exe ad_start.bsp -s -p x -l z -t 1 0.5 32`
- `bsp2svg.exe elders7.bsp -s -p y -l z -t 1 0.15 32`
- `bsp2svg.exe saint.bsp -s -t 1 0.2 96`
- `bsp2svg.exe qbj2_start.bsp -s -p y -t 1 0.2 64`
- `bsp2svg.exe ad_tears.bsp -p x -t 1 0.2 96 -s`

# Screenshots 
zigi's Tellus Terminus, part of Alkaline [high resolution screenshot](https://imgur.com/a/HkLmmfb)

![image](https://github.com/joshuaskelly/quake-cli-tools/assets/6061770/b7e4b18d-43e5-4dd1-a187-5aade9a3ba03)
Start map of qbj2 - Ears to the Heavens by Makkon, projected and sliced along by the `y` axis, with half of the slices hidden

![ad_start_x](https://github.com/joshuaskelly/quake-cli-tools/assets/6061770/9eafeafd-d55e-45cb-b439-f82962515f2b)
Start map from Arcane Dimensions, viewed from the `x` axis, sliced by the `z` axis